### PR TITLE
Fix commenting

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -5,7 +5,7 @@
   <key>name</key>
   <string>Comments</string>
   <key>scope</key>
-  <string>text.feature</string>
+  <string>feature.behat</string>
   <key>settings</key>
   <dict>
     <key>shellVariables</key>


### PR DESCRIPTION
The scope name in the tmLanguage files and the Comments.tmPreferences files didn't match. Changing these to match makes it possible to use Ctrl + / to comment out lines.
